### PR TITLE
Added: github_activities agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 __pycache__/
+env

--- a/agents/github_activities/README.rst
+++ b/agents/github_activities/README.rst
@@ -1,0 +1,137 @@
+GitHub Activities Plugin
+=========================
+
+The **GitHub Activities Plugin** is designed to fetch events from a public GitHub repository. It supports fetching a configurable number of events like forking, push, etc sorted by date.
+
+Features
+--------
+
+- Fetch events of a GitHub repo using its URL.
+- Retrieve a specified number of events.
+- Simple integration with the PlugFlow framework.
+
+Installation
+------------
+
+The plugin uses an API and thus does not need the Installation of any dependencies.
+
+Parameters
+----------
+
+The plugin accepts the following parameters:
+
+- ``repo_url`` (str): The URL of the GitHub repository.
+- ``max_events`` (int): The maximum number of events to fetch (default: 10).
+
+Example Usage
+-------------
+
+To execute the plugin, use the PlugFlow CLI:
+
+.. code-block:: bash
+
+    python main.py execute github-activities --params '{"repo_url": "https://github.com/data-artisans-centre/plugflow-core", "max_events": 10}'
+
+Output
+------
+
+The plugin returns the fetched events as a list of JSON objects. Each event contains the following fields:
+
+- ``id``: A unique identifier for the event.
+- ``type``: The type of event, such as PullRequestReviewEvent.
+- ``actor``: Details about the user who performed the event:
+    - ``id``: Unique identifier of the user.
+    - ``login``: Username of the user.
+    - ``display_login``: Display name of the user.
+    - ``avatar_url``: URL of the user's avatar image.
+    - ``repo``: Information about the repository associated with the event:
+
+- ``id``: Unique identifier of the repository.
+- ``name``: Name of the repository in the format owner/repo.
+- ``url``: API URL of the repository.
+- ``payload``: Details specific to the event type:
+- ``action``: The action performed, such as created.
+
+The response will have more parts specific to the type of event.
+
+Example:
+
+.. code-block:: json
+
+    
+[
+  {
+    "id": "1234567",
+    "type": "PullRequestReviewEvent",
+    "actor": {
+      "id": 1234567,
+      "login": "JaneDoe",
+      "display_login": "JaneDoe",
+      "avatar_url": "https://avatars.githubusercontent.com/u/123456?"
+    },
+    "repo": {
+      "id": 12345,
+      "name": "user/repo",
+      "url": "https://api.github.com/repos/user/repo"
+    },
+    "payload": {
+      "action": "created",
+      "review": {
+        "id": 1234567,
+        "state": "changes_requested",
+        "html_url": "https://github.com/user/repo/pull/2#pullrequestreview-123456",
+        "pull_request_url": "https://api.github.com/repos/user/repo/pulls/2",
+        "submitted_at": "2024-11-25T12:51:25Z"
+      },
+      "pull_request": {
+        "id": 324562,
+        "html_url": "https://github.com/user/repo/pull/3",
+        "title": "Added templates",
+        "created_at": "2024-11-25T12:44:43Z",
+        "updated_at": "2024-11-25T12:51:25Z",
+        "state": "open"
+      }
+    }
+  }
+]
+
+
+Testing
+-------
+
+To test the plugin, use the provided test suite located in the ``tests`` directory.
+
+Run all tests:
+
+.. code-block:: bash
+
+    pytest agents/github_activities/tests
+
+Health Check
+------------
+
+The plugin includes a ``health_check`` method to verify its operational status. The method attempts to fetch events from a known repo and returns a status message.
+
+Example health check output:
+
+.. code-block:: json
+
+    {
+        "status": "healthy",
+        "message": "Service is available"
+    }
+
+Contributing
+------------
+
+Contributions to improve or enhance the plugin are welcome. Follow these steps:
+
+1. Fork the repository.
+2. Create a new branch for your changes.
+3. Submit a pull request with a detailed description of your changes.
+
+License
+-------
+
+This plugin is distributed under the MIT License. See the LICENSE file for more information.
+

--- a/agents/github_activities/__init__.py
+++ b/agents/github_activities/__init__.py
@@ -1,0 +1,121 @@
+import json
+from itertools import islice
+from core.base import AgentBase
+from log import logger
+import requests
+
+class GitHubActivitiesAgent(AgentBase):
+    """Agent to fetch recent activities of a public GitHub repository."""
+
+    def execute(self, repo_url, max_events = 10):
+        """
+        Fetch recent events associated with a public repository on GitHub
+
+        Args:
+            repo_url (str): The url of github repository
+
+        Returns:
+            list: A list of dictionaries containing event data.
+
+        Raises:
+        ValueError: If:
+            - The `repo_url` is invalid or improperly formatted.
+            - The GitHub API response cannot be parsed.
+            - The GitHub API returns data in an unexpected format.
+            - Serialization of events to JSON fails.
+        ConnectionError: If there is a network connectivity issue.
+        Timeout: If the request to the GitHub API times out.
+        InvalidURL: If the repository URL is malformed.
+        HTTPError: If the GitHub API returns a non-2xx status code.
+        JSONDecodeError: If the GitHub API response is not valid JSON.
+        IndexError: If the URL does not contain enough components to extract the repository owner and name.
+        Exception: For any other unexpected errors.
+        """
+        try:
+            # Validate repo_url
+            if not isinstance(repo_url, str) or "github.com" not in repo_url:
+                raise ValueError("Invalid repository URL format.")
+            
+            split_url = str(repo_url).split("/")
+            if len(split_url) < 5:
+                raise ValueError("Repository URL must include owner and repo name.")
+            repo_name = split_url[4]
+            repo_owner = split_url[3]
+            logger.info(f"Fetching events of repository: {repo_name}")
+            url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/events"
+            headers = {
+                "Accept": "application/vnd.github+json"
+            }
+            response = requests.get(url, headers=headers)
+            # check HTTP response status
+            response.raise_for_status() 
+            try:
+                events = response.json()
+            except json.JSONDecodeError as e:
+                raise ValueError("Invalid JSON response from GitHub API.") from e
+            
+            if not isinstance(events, list):
+                raise ValueError("Unexpected data format received from GitHub API.")
+            limited_events = list(islice(events, max_events))
+            # Convert the list of comments to a JSON-formatted string
+            try:
+                events_json = json.dumps(limited_events, indent=4)
+            except TypeError as e:
+                raise ValueError("Failed to serialize events to JSON.") from e
+           
+            return events_json
+        
+        except requests.exceptions.ConnectionError as e:
+            logger.error("Connection error: Unable to reach GitHub API.")
+            raise ValueError("Network issue. Please check your internet connection.") from e
+
+        except requests.exceptions.Timeout as e:
+            logger.error("Request timed out.")
+            raise ValueError("GitHub API request timed out. Try again later.") from e
+
+        except requests.exceptions.InvalidURL as e:
+            logger.error(f"Invalid URL: {repo_url}")
+            raise ValueError("The repository URL is malformed.") from e
+
+
+        except IndexError as e:
+            logger.error("URL splitting failed.")
+            raise ValueError("Invalid repository URL format.") from e
+
+        except ValueError as e:
+            logger.error(f"Value error: {e}")
+            raise
+
+
+        except Exception as e:
+            logger.error(f"An error occurred: {e}")
+            raise ValueError("Failed to fetch events. Please check the repository URL and try again.") from e
+
+    def health_check(self):
+        """
+        Check if the Github API is functional.
+
+        Returns:
+            dict: Health status of the plugin.
+        """
+        try:
+            logger.info("Performing health check...")
+            
+            # Test with a known valid repo URL
+            
+            
+            logger.info(f"Fetching events of repository: plugflow-core")
+            url = f"https://api.github.com/repos/data-artisans-centre/plugflow-core/events"
+            headers = {
+                "Accept": "application/vnd.github+json"
+            }
+            response = requests.get(url, headers=headers)
+            response.raise_for_status()  
+            events = response.json()
+            if not isinstance(events, list) or not events:
+                raise ValueError("Unexpected or empty response data.")
+            logger.info("Health check passed.")
+            return {"status": "healthy", "message": "Service is available"}
+        except Exception as e:
+            logger.error(f"Health check failed: {e}")
+            return {"status": "unhealthy", "message": str(e)}

--- a/agents/github_activities/manifest.json
+++ b/agents/github_activities/manifest.json
@@ -1,0 +1,5 @@
+{
+    "name": "github-activities",
+    "entry_point": "__init__",
+    "class_name": "GitHubActivitiesAgent"
+}

--- a/agents/github_activities/tests/test_github_activities.py
+++ b/agents/github_activities/tests/test_github_activities.py
@@ -1,0 +1,70 @@
+import pytest
+from agents.github_activities import GitHubActivitiesAgent
+import requests
+import json
+class MockGitHubAPI:
+    """Mock class for GitHub API responses. """
+    def get_events_from_repo(self, repo_url):
+        if "invalid-repo" in repo_url:
+            raise ValueError("Invalid repository URL")
+        # Return a generator simulating a valid response
+        yield {"type": "PushEvent", "actor": {"login":"MockUser"}}
+
+
+@pytest.fixture
+def github_activities_agent(monkeypatch):
+    """Fixture to initialize the GitHubActivitiesAgent with a mock API."""
+    agent = GitHubActivitiesAgent()
+    # Patch the GitHub API with the mock class
+    def mock_get(url, headers=None):
+        if "invalid-repo" in url:
+            mock_response = requests.Response()
+            mock_response.status_code = 404
+            mock_response.reason = "Not Found"
+            raise requests.exceptions.HTTPError(response=mock_response)
+        mock_response = requests.Response()
+        mock_response.status_code = 200
+        mock_response._content = b'[{"type": "PushEvent", "actor": {"login": "MockUser"}}]'
+        return mock_response
+       
+    monkeypatch.setattr("requests.get", mock_get)
+    return agent
+
+
+def test_execute_success(github_activities_agent):
+    """Test successful execution of the GitHubActivitiesAgent"""
+    repo_url = "https://github.com/test-user/test-repo"
+    response = github_activities_agent.execute(repo_url, max_events=1)
+    events = json.loads(response)
+    assert len(events) == 1, "Expected one event in the response."
+    assert events[0]["type"] == "PushEvent", "Expected event type 'PushEvent'."
+    assert events[0]["actor"]["login"] == "MockUser", "Expected actor login 'MockUser'."    
+
+
+def test_execute_invalid_url(github_activities_agent):
+    """Test execution with an invalid repo."""
+    repo_url = "https://github.com/test-user/invalid-repo"
+    with pytest.raises(ValueError, match="Failed to fetch events. Please check the repository URL and try again."):
+        github_activities_agent.execute(repo_url, max_events=1)
+
+
+def test_health_check_success(github_activities_agent):
+    """Test health check success."""
+    health = github_activities_agent.health_check()
+    assert health["status"] == "healthy", "Expected health status to be 'healthy'."
+    assert "Service is available" in health["message"], "Expected success message in health check."
+
+
+def test_health_check_failure(monkeypatch):
+    """Test health check failure."""
+    def mock_get(*args, **kwargs):
+        raise Exception("Mock service failure")
+
+    # Patch the `requests.get` method to simulate a failure
+    monkeypatch.setattr("requests.get", mock_get)
+
+    agent = GitHubActivitiesAgent()
+    health = agent.health_check()
+    assert health["status"] == "unhealthy", "Expected health status to be 'unhealthy'."
+    assert "Mock service failure" in health["message"], "Expected failure message in health check."
+


### PR DESCRIPTION
Added an agent that collects the latest events (e.g. push, forks, pull requests) of a public GitHub repository.
Tests have been added along with required documentation.
The agent in working condition:
![Screenshot 2024-11-28 223446](https://github.com/user-attachments/assets/8fb97870-d33f-4706-bd4c-5e661a6fac63)
4 tests were run and all passed.
![Screenshot 2024-11-28 223419](https://github.com/user-attachments/assets/9d1c6afe-0d33-4211-88b7-5bb81b503858)
